### PR TITLE
QQ page's footer sticks to the bottom

### DIFF
--- a/assets/js/qq-position.js
+++ b/assets/js/qq-position.js
@@ -251,13 +251,12 @@ function qqBoxPosition() {
     // GETTING FOOTER TO STICK TO BOTTOM AT 1225+
     if (qqScreenWidth < 1225) {
         // var binocularsArea = (smallPairRowCountInt * ((26.52 / 2) - 0.57));    /* ONLY FOR <1225!!! ((325 / 2) - 7)) + 'px' is the distance from the top of one small binoculars to the top of one in the next row  */
-        var binocularsArea = (smallPairRowCountInt * ((90 / 2) - 0.57));    /* TESTING!!! ((325 / 2) - 7)) + 'px' is the distance from the top of one small binoculars to the top of one in the next row  */
+        var binocularsArea = (smallPairRowCountInt * ((26.52 / 2) - 0.57));    /* TESTING!!! ((325 / 2) - 7)) + 'px' is the distance from the top of one small binoculars to the top of one in the next row  */
         var background = document.getElementById('background');
         var qqPageTitleHeight = document.getElementById('qqpagetitle').offsetHeight;
         var qqPageTextHeight = document.getElementById('qqpagetext').firstElementChild.offsetHeight;
-        background.style.height = (binocularsArea - (qqPageTitleHeight + qqPageTextHeight)) + 'vw';
-        // background.style.height = 'calc(' + binocularsArea + 'vw - ' (parseInt(qqPageTitleHeight) + parseInt(qqPageTextHeight)) + 'px)';
-        
+        // background.style.height = (binocularsArea - (qqPageTitleHeight + qqPageTextHeight)) + 'vw';
+        background.style.height = 'calc(' + binocularsArea + 'vw - ' + (parseInt(qqPageTitleHeight) + parseInt(qqPageTextHeight)) + 'px + 2.5rem)';
         var footerHeight = document.getElementsByTagName('footer')[0].offsetHeight; 
         var body = document.getElementsByTagName('body')[0];
         body.style.height = binocularsArea + footerHeight;
@@ -268,7 +267,8 @@ function qqBoxPosition() {
         var background = document.getElementById('background');
         var qqPageTitleHeight = document.getElementById('qqpagetitle').offsetHeight;
         var qqPageTextHeight = document.getElementById('qqpagetext').firstElementChild.offsetHeight;
-        background.style.height = (binocularsArea - (qqPageTitleHeight + qqPageTextHeight)) + 'px';
+        // background.style.height = (binocularsArea - (qqPageTitleHeight + qqPageTextHeight)) + 'px';
+        background.style.height = 'calc(' + (binocularsArea - (qqPageTitleHeight + qqPageTextHeight)) + 'px + 2.5rem)';
         var footerHeight = document.getElementsByTagName('footer')[0].offsetHeight; 
         var body = document.getElementsByTagName('body')[0];
         body.style.height = binocularsArea + footerHeight;


### PR DESCRIPTION
Except at certain screen sizes ~950-1225 (I think, but needs to more verifying). Can fix this by changing line 259 to make the last part of calc() (currently 2.5rem to account for max randomized marign height) to be more than 2.5rem for screensizes less than 1225.