### PR TITLE
QQ page parallax is accounted for with footer position

### DIFF
--- a/assets/js/qq-position.js
+++ b/assets/js/qq-position.js
@@ -250,30 +250,25 @@ function qqBoxPosition() {
 
     // GETTING FOOTER TO STICK TO BOTTOM AT 1225+
     if (qqScreenWidth < 1225) {
-        // var binocularsArea = (smallPairRowCountInt * ((26.52 / 2) - 0.57));    /* ONLY FOR <1225!!! ((325 / 2) - 7)) + 'px' is the distance from the top of one small binoculars to the top of one in the next row  */
         var binocularsArea = (smallPairRowCountInt * ((26.52 / 2) - 0.57));    /* TESTING!!! ((325 / 2) - 7)) + 'px' is the distance from the top of one small binoculars to the top of one in the next row  */
         var background = document.getElementById('background');
         var qqPageTitleHeight = document.getElementById('qqpagetitle').offsetHeight;
-        var qqPageTextHeight = document.getElementById('qqpagetext').firstElementChild.offsetHeight;
-        // background.style.height = (binocularsArea - (qqPageTitleHeight + qqPageTextHeight)) + 'vw';
-        background.style.height = 'calc(' + binocularsArea + 'vw - ' + (parseInt(qqPageTitleHeight) + parseInt(qqPageTextHeight)) + 'px + 2.5rem)';
+        var qqPageTextHeight = document.getElementById('qqpagetext').firstElementChild.offsetHeight; 
+        // background.style.height = 'calc(' + binocularsArea + 'vw - ' + (parseInt(qqPageTitleHeight) + parseInt(qqPageTextHeight)) + 'px + 2.5rem)';
+        background.style.height = 'calc(' + (binocularsArea * 1.22) + 'vw - ' + (parseInt(qqPageTitleHeight) + parseInt(qqPageTextHeight)) + 'px + 2.5rem)';    // 1.22 comes from the scroll rate for small glasses in qq-parallax.js (the 1 comes from 100% scroll speed and the 0.22 comes from 22% slower than that...); 2.5rem comes from the maximum randomized margin set to each binoculars in questionqueue.php
         var footerHeight = document.getElementsByTagName('footer')[0].offsetHeight; 
         var body = document.getElementsByTagName('body')[0];
         body.style.height = binocularsArea + footerHeight;
-        // TEST!!!
-        document.getElementById('qqtest').innerHTML = '< 1225!' + body.offsetHeight;
     } else {
         var binocularsArea = (smallPairRowCountInt * ((325 / 2) - 7));    /* ONLY FOR 1225+!!! ((325 / 2) - 7)) + 'px' is the distance from the top of one small binoculars to the top of one in the next row  */
         var background = document.getElementById('background');
         var qqPageTitleHeight = document.getElementById('qqpagetitle').offsetHeight;
         var qqPageTextHeight = document.getElementById('qqpagetext').firstElementChild.offsetHeight;
-        // background.style.height = (binocularsArea - (qqPageTitleHeight + qqPageTextHeight)) + 'px';
-        background.style.height = 'calc(' + (binocularsArea - (qqPageTitleHeight + qqPageTextHeight)) + 'px + 2.5rem)';
+        // background.style.height = 'calc(' + (binocularsArea - (qqPageTitleHeight + qqPageTextHeight)) + 'px + 2.5rem)';
+        background.style.height = 'calc(' + ((binocularsArea * 1.22) - (qqPageTitleHeight + qqPageTextHeight)) + 'px + 2.5rem)';    // 1.22 comes from the scroll rate for small glasses in qq-parallax.js (the 1 comes from 100% scroll speed and the 0.22 comes from 22% slower than that...); 2.5rem comes from the maximum randomized margin set to each binoculars in questionqueue.php
         var footerHeight = document.getElementsByTagName('footer')[0].offsetHeight; 
         var body = document.getElementsByTagName('body')[0];
         body.style.height = binocularsArea + footerHeight;
-        // TEST!!!
-        document.getElementById('qqtest').innerHTML = '1225+!' + body.offsetHeight;
     }
 
 

--- a/site/templates/questionqueue.php
+++ b/site/templates/questionqueue.php
@@ -75,7 +75,7 @@
 				<?php echo $page->text()->kirbytext() ?>
 			</span>
 
-			<p id="qqtest">hola</p>
+			<!-- <p id="qqtest">hola</p> -->
 
 			<!-- </div> -->
 


### PR DESCRIPTION
Now footer stays at bottom at all screensizes (both screenwidths and screenheights) because I took into account the parallax scroll rate of the small glasses layer, which was delaying the small glasses layer from getting all the way to the bottom by the time it was expected to have (which resulted in it seeming to be too tall, and footer not sticking all the way to the bottom).