### PR TITLE
Home glasses icon is now visible between 1225px and 1245px screenwidths

### DIFF
--- a/assets/css/mediaqueries.css
+++ b/assets/css/mediaqueries.css
@@ -549,7 +549,7 @@
     #homeicon {
         display: inline;
         position: absolute;
-        left: calc(-100vw + 440px + 0.422rem);
+        left: calc(-100vw + 677px + 0.422rem);
         top: 0.422rem;
         width: 1.301rem;    
         padding: 0.316rem;    }


### PR DESCRIPTION
It was getting kicked off the left edge of the page because the calc() wasn't taking into account the new width of menu once "Question Queue" was added.