### PR TITLE
p5 canvas lightbox toggle button functionality is finalized!

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -52,4 +52,5 @@ RewriteRule ^(.*) index.php [L]
 #
 # php_flag short_open_tag on
 
+# Prevent visitors from navigating to my "/content" directory with URL
 Options -Indexes

--- a/assets/css/somepages.css
+++ b/assets/css/somepages.css
@@ -1,8 +1,14 @@
 /* TESTING P5!!!! */
 
 .fullscreentoggle {
-    width: 25px;    /* just for now */
-    float: right;    }
+    box-sizing: content-box;
+    height: 0.844rem;
+    width: 0.844rem;
+    padding: 0.422rem;
+    cursor: pointer;
+    float: right;
+    position: relative;
+    top: 0;    }
 
 .toregview {
     position: absolute;
@@ -26,8 +32,6 @@
     display: block;
     margin-left: auto;
     margin-right: auto;    }
-
-
 
 
 

--- a/assets/js/canvasfullscreen-PRE-EVENT-LISTENER-CHANGES.js
+++ b/assets/js/canvasfullscreen-PRE-EVENT-LISTENER-CHANGES.js
@@ -28,17 +28,6 @@ function canvasFullScreen() {
 		//[3.) <figcaption> (OPTIONAL!)]
 		
 	} // close for loop
-
-
-	// --------------------------------------------------------------------------------
-	// ADD OTHER LIGHTBOX-NECESSARY FUNCTIONALITY
-
-	// turn OFF event listener for closing lightbox 
-	// otherwise that function to close lightbox will run immediately upon clicking the same lightbox toggle button that opens it, and it will never appear open
-	window.removeEventListener('click', xOrRegViewIconOrWhiteSpaceClick);
-	
-	// upon load (when this function as a whole is called) turn ON event listener to open lightbox
-	window.addEventListener('click', canvasToLightbox);
 	
 } // close canvasFullScreen function
 
@@ -132,13 +121,6 @@ function canvasToLightbox(e) {
         // turning on an event listener only when lightbox is open; this way hitting "escape" key can close lightbox (via "function addESC()")
     	document.addEventListener('keydown', canvasCloseEsc);
 
-    	// turn OFF event listener for opening lightbox 
-		// otherwise that function to open lightbox will run immediately upon clicking the same lightbox toggle button that closes it, and it will never appear close (via the toggle button at least)
-		window.removeEventListener('click', canvasToLightbox);
-
-		// turn on event listener to close lightbox
-		window.addEventListener('click', xOrRegViewIconOrWhiteSpaceClick);
-
 
 		// --------------------------------------------------------------------------------
 		// FLESH OUT ALL LIGHTBOX-RELATED BUTTONS except for chevron, which must be defined within if-statement at end (dependent upon existence of <figcaption> or not)
@@ -148,8 +130,7 @@ function canvasToLightbox(e) {
 		lightboxToggle.setAttribute('title', 'Close fullscreen mode');
 		lightboxToggle.setAttribute('alt', 'Close fullscreen mode');
 		lightboxToggle.setAttribute('id', 'toregview');
-		lightboxToggle.setAttribute('class', 'fullscreentoggle');
-		lightboxToggle.classList.add('yellowhover');
+		lightboxToggle.setAttribute('class', 'fullscreentoggle yellowhover');
 		lightboxToggle.setAttribute('data-canvas-x', '');		
 
 		// add "x"; created as <img> node within var list
@@ -199,6 +180,7 @@ window.addEventListener('click', canvasToLightbox, false);
 
 
 // *************************************************************************************************************
+// NAMED FUNCTION ----------------------------------------------------------------------------
 function canvasClose() {
 	
     // all UI var's defined except for chevron, which must be defined within if-statement at end (dependent upon existence of <figcaption> or not)
@@ -241,12 +223,9 @@ function canvasClose() {
 	// ADD OTHER LIGHTBOX-REMOVAL FUNCTIONALITY
 
 	// RETURN TO ACTIVATE THESE LATER!
-    document.removeEventListener('keydown', canvasCloseEsc); // is turned on when lightbox is open, and only needed when it's open, so removing to save resources when not needed
+    document.removeEventListener('keydown', addESC); // is turned on when lightbox is open, and only needed when it's open, so removing to save resources when not needed
 
-    // turning back ON event listener that opens lightbox, from regular view
-	window.addEventListener('click', canvasToLightbox);
-
-    // remove #hash from URL and allow page to scroll again once lightbox is closed
+    // call NAMED function
     removeHashReturnScroll();
 
 
@@ -296,7 +275,7 @@ function xOrRegViewIconOrWhiteSpaceClick(e) {
 }
 
 // responds to a click on the lightbox "x" button
-// window.addEventListener('click', xOrRegViewIconOrWhiteSpaceClick, false);
+window.addEventListener('click', xOrRegViewIconOrWhiteSpaceClick, false);
 
 
 

--- a/assets/js/canvasfullscreen-PRE-FULLSCREEN-BUTTON-POSITION.js
+++ b/assets/js/canvasfullscreen-PRE-FULLSCREEN-BUTTON-POSITION.js
@@ -20,7 +20,7 @@ function canvasFullScreen() {
 		fullScreenButton.setAttribute('src', 'https://curiositycoloredglasses.com/assets/images/to-full-screen.svg');
 		fullScreenButton.setAttribute('title', 'View in fullscreen mode');
 		fullScreenButton.setAttribute('alt', 'View in fullscreen mode');
-		fullScreenButton.setAttribute('class', 'fullscreentoggle tofullscreen');
+		fullScreenButton.setAttribute('class', 'fullscreentoggle tofullscreen yellowhover');
 		allCanvas[i].parentNode.appendChild(fullScreenButton);
 		// DOM order within #sketch-holder is now:
 		// 1. <canvas>
@@ -52,6 +52,7 @@ function canvasToLightbox(e) {
 		var fullScreenIcon = sketchHolder.lastElementChild;
 		fullScreenIcon.parentNode.removeChild(fullScreenIcon);
 
+		/*/
 		// style caption
 		if (sketchHolder.firstElementChild.nextElementSibling.hasAttribute('data-canvas-figcaption')) {
 			sketchHolder.firstElementChild.nextElementSibling.classList.add('lightboxcaption', 'hide');
@@ -66,6 +67,9 @@ function canvasToLightbox(e) {
     	    chevron.setAttribute('canvascaptiontoggle', '');
 	        sketchHolder.appendChild(chevron);
 		} 
+		*/
+
+
 		// add "x"
 		var closeX = document.createElement('img');
 		closeX.setAttribute('src', 'https://curiositycoloredglasses.com/assets/images/x.svg');
@@ -83,16 +87,24 @@ function canvasToLightbox(e) {
 		regViewIcon.setAttribute('src', 'https://curiositycoloredglasses.com/assets/images/to-regular-view.svg');
 		regViewIcon.setAttribute('title', 'Close fullscreen mode');
 		regViewIcon.setAttribute('alt', 'Close fullscreen mode');
-		regViewIcon.setAttribute('class', 'fullscreentoggle toregview');
+		regViewIcon.setAttribute('id', 'toregview');
+		regViewIcon.setAttribute('class', 'fullscreentoggle yellowhover');
 		regViewIcon.setAttribute('data-canvas-x', '');
 		sketchHolder.appendChild(regViewIcon);
 		document.getElementById('fullscreentest').innerHTML = regViewIcon.getAttribute('title');
+
+
+
+
+
+
 		// DOM order within #sketch-holder is now:
 		// 1. <canvas>
 		// [2. <figcaption> (OPTIONAL!)]
-		// [3. chevron for figcaption toggling (OPTIONAL!)] ADDED HERE; SHOULD ONLY EXIST WITHIN LIGHTBOX
-		// 4. .close-x button ADDED HERE; SHOULD ONLY EXIST WITHIN LIGHTBOX
-		// 5. .toregview button
+		// 3. .close-x button ADDED HERE; SHOULD ONLY EXIST WITHIN LIGHTBOX
+		// 4. #toregview button
+		// [5. chevron for figcaption toggling (OPTIONAL!)] ADDED HERE; SHOULD ONLY EXIST WITHIN LIGHTBOX
+
 
 		// now resize canvas for lightbox (but... vvv)
 		// TRANSFORM #sketch-holder INTO A LIGHTBOX-BG-LOOKALIKE (USE CSS FOR STYLING VIA JS-ADDED "sketch-lightbox" CLASS)
@@ -156,6 +168,29 @@ function canvasToLightbox(e) {
 
     	// turning on an event listener only when lightbox is open; this way hitting "escape" key can close lightbox (via "function addESC()")
     	document.addEventListener('keydown', canvasCloseEsc);
+    	// set hash for URL when open
+    	if (sketchHolder.hasAttribute('data-hash')) {
+			location.hash = sketchHolder.getAttribute('data-hash');
+		}
+	    // stop V scrollability
+    	document.documentElement.style.overflow = 'hidden';
+
+   		// style caption: if statemtn must come after everything else...
+   		// because nothing after it within this function is read if its condition is not met 
+   		// (i.e. if there is NOT a caption)
+		if (sketchHolder.firstElementChild.nextElementSibling.hasAttribute('data-canvas-figcaption')) {
+			sketchHolder.firstElementChild.nextElementSibling.classList.add('lightboxcaption', 'hide');
+			// add caption-toggling chevron
+			var chevron = document.createElement('img');
+			chevron.setAttribute('src', 'https://curiositycoloredglasses.com/assets/images/up-arrowhead.svg');	
+	        chevron.setAttribute('title', 'Toggle caption visibility');
+        	chevron.setAttribute('alt', 'Toggle caption visibility');
+    	    chevron.setAttribute('id', 'captiontoggle');
+	        // chevron.setAttribute('class', 'close-x yellowhover turn180'); // use this line instead of the next if I want chevron to start int eh other direction it does now
+        	chevron.setAttribute('class', 'close-x yellowhover');
+    	    chevron.setAttribute('canvascaptiontoggle', '');
+	        sketchHolder.appendChild(chevron);
+		} 
 	
 	} // close if-statement that defines what was clicked
 } // function
@@ -173,20 +208,22 @@ function canvasClose() {
     	if (sketchHolder.firstElementChild.nextElementSibling.hasAttribute('data-canvas-figcaption')) {
 			sketchHolder.firstElementChild.nextElementSibling.classList.remove('lightboxcaption');
 			sketchHolder.firstElementChild.nextElementSibling.classList.remove('hide');
-			var canvasCaptionToggle = sketchHolder.firstElementChild.nextElementSibling.nextElementSibling;
+			// var canvasCaptionToggle = sketchHolder.firstElementChild.nextElementSibling.nextElementSibling;
+			var canvasCaptionToggle = document.getElementById('captiontoggle');
 			sketchHolder.removeChild(canvasCaptionToggle);
 		}
 		// remove "x" button
 		var closeX = document.getElementById('lightboxclose');
 		sketchHolder.removeChild(closeX);
 		// swap back out regview icon for fullscreen icon again + position
-        var regViewIcon = sketchHolder.lastElementChild;
+        // var regViewIcon = sketchHolder.lastElementChild;
+        var regViewIcon = document.getElementById('toregview');
         sketchHolder.removeChild(regViewIcon);
         var fullScreenButton = document.createElement('img');
         fullScreenButton.setAttribute('src', 'https://curiositycoloredglasses.com/assets/images/to-full-screen.svg');
 		fullScreenButton.setAttribute('title', 'View in fullscreen mode');
 		fullScreenButton.setAttribute('alt', 'View in fullscreen mode');
-		fullScreenButton.setAttribute('class', 'fullscreentoggle tofullscreen');
+		fullScreenButton.setAttribute('class', 'fullscreentoggle tofullscreen yellowhover');
 		sketchHolder.appendChild(fullScreenButton);
 		// DOM order within #sketch-holder is now back to:
 		// 1. <canvas>
@@ -213,9 +250,9 @@ function canvasClose() {
         }
 
 		// RETURN TO ACTIVATE THESE LATER!
-        // document.removeEventListener('keydown', addESC); // is turned on when lightbox is open, and only needed when it's open, so removing to save resources when not needed
+        document.removeEventListener('keydown', addESC); // is turned on when lightbox is open, and only needed when it's open, so removing to save resources when not needed
         // call NAMED function
-        // removeHashReturnScroll();
+        removeHashReturnScroll();
 }
 
 
@@ -257,8 +294,10 @@ function toggleCanvasCaption(e) {
     var captionToggleIcon = e.target;
     if (captionToggleIcon.hasAttribute('canvascaptiontoggle')) {
         captionToggleIcon.classList.toggle('turn180');
-        captionToggleIcon.previousElementSibling.removeAttribute('style');
-        captionToggleIcon.previousElementSibling.classList.toggle('hide');
+        // captionToggleIcon.previousElementSibling.removeAttribute('style');
+        // captionToggleIcon.previousElementSibling.classList.toggle('hide');
+        captionToggleIcon.parentNode.firstElementChild.nextElementSibling.removeAttribute('style');
+        captionToggleIcon.parentNode.firstElementChild.nextElementSibling.classList.toggle('hide');
     }
 }
 

--- a/content/blog/20170409-carbonless-copy-paper/blogarticle.txt
+++ b/content/blog/20170409-carbonless-copy-paper/blogarticle.txt
@@ -29,10 +29,12 @@ Text:
 Carbonless copy paper also known as (vocab: CCP url: ccp), non-carbon copy paper, or (vocab: NCR paper url: ncr-paper) consists of sheets of paper that are coated with micro-encapsulated dye or ink or a reactive clay. The back of the first sheet is coated with micro-encapsulated dye (referred to as a Coated Back or CB sheet). The lowermost sheet is coated on the top surface with a clay that quickly reacts with the dye to form a permanent mark (Coated Front, CF). Any intermediate sheets are coated with clay on top and dye on the bottom (Coated Front and Back, CFB).
 
 <figure id="sketch-holder" data-hash="circles">
+
 <figcaption class="xs-textface">
 <hr class="toprule">
 Just testing out my little figcaption for my p5 test!
 </figcaption>
+
 </figure>
 
 (image: dot.svg)


### PR DESCRIPTION
Now it keeps the same exact DOM object for the "go to lightbox" and "go to regular view", just swap the src attribute (the image) and adds and removes eventListeners within the functions each are responsible for when clicked (inspired by the escape key function; see Github issue I had made for that which has an explanatory link from Harvard).