### PR TITLE
<title> tag now reference's post page's "name" attribute, not sub-fol…

### DIFF
--- a/site/snippets/head-title-all-but-home.php
+++ b/site/snippets/head-title-all-but-home.php
@@ -1,5 +1,4 @@
   <!-- This is what shows when you bookmark this page, and what's in the browser tab -->
   <title>
-    <?php echo $page->title()->html() ?> | Curiosity-Colored Glasses
+    <?php echo $page->name()->html() ?> | Curiosity-Colored Glasses
   </title>
-

--- a/site/snippets/header.php
+++ b/site/snippets/header.php
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
 
-  <title><?= $site->title()->html() ?> | <?= $page->title()->html() ?></title>
+  <title><?= $site->title()->html() ?> | <?= $page->name()->html() ?></title>
   <meta name="description" content="<?= $site->description()->html() ?>">
 
   <?= css('assets/css/index.css') ?>


### PR DESCRIPTION
…der's "title" attribute

This was a relic bug after I fixed the search results by changing the page's "title" attribute (in its blueprint .yml file) to be called a "name" attribute instead. So I needed to point the <title> tag to the "name" attribute so it shows the post name in the browser tab (and when bookmarking).