### PR TITLE
Non-post pages now have their names in the browser tab again

### DIFF
--- a/content/1-hello/hello.txt
+++ b/content/1-hello/hello.txt
@@ -1,4 +1,4 @@
-Title: Hello
+Name: Hello
 
 ----
 

--- a/content/2-questionqueue/questionqueue.txt
+++ b/content/2-questionqueue/questionqueue.txt
@@ -1,4 +1,4 @@
-Title: Question Queue
+Name: Question Queue
 
 ----
 
@@ -6,4 +6,4 @@ Text: These queries are on my horizon. (link: https://twitter.com/CuriosityColor
 
 ----
 
-Illustration: 
+Illustration:

--- a/content/3-library/library.txt
+++ b/content/3-library/library.txt
@@ -1,4 +1,4 @@
-Title: Library
+Name: Library
 
 ----
 

--- a/content/4-archive/archive.txt
+++ b/content/4-archive/archive.txt
@@ -1,16 +1,16 @@
-Title: Archive
+Name: Archive
 
 ----
 
-Text: 
+Text:
 
 ----
 
-Years: 
+Years:
 
-- 
+-
   year: "2015"
-- 
+-
   year: "2016"
-- 
+-
   year: "2017"

--- a/content/blog/20170409-measure-of-a-mountain/blogarticle.txt
+++ b/content/blog/20170409-measure-of-a-mountain/blogarticle.txt
@@ -18,11 +18,11 @@ Guestwriter:
 
 ----
 
-Tags: mountains,measurements,geology,Mars,volcanoes,science,supercalafragalisticexpialidocious,superdupertrooper
+Tags: mountains,measurements,geology,Mars,volcanoes,science,supercalafragalisticexpialidocious,superdupertrooper,all
 
 ----
 
-Intro: On maps, a mountain’s height is always shown solely as its peak’s altitude above sea level. This seems like a bit of a cop-out: is the mountain itself really that tall? Or is it just standing on the shoulders of a very tall plateau, so to speak? Then again, determining the base from which to measure any mountain seems like quite the slippery slope once you get down to it, so I do understand and sympathize with the sea level approach adopted by us Earthlings. But what about pinnacle-filled planets and moons that lack oceans—how do we measure their mountains? And even on Earth, how are the high and low tides of sea level reconciled in order to arrive at heights so specific that they often indicate individual feet, and even inches in some cases?
+Intro: On maps, a mountain’s height is always shown solely as its peak’s elevation above sea level. This seems like a bit of a cop-out: is the mountain itself really that tall? Or is it just standing on the shoulders of a very tall plateau, so to speak? Then again, determining the base from which to measure any mountain seems like quite the slippery slope once you get down to it, so I do understand and sympathize with the sea level approach adopted by us Earthlings. But what about pinnacle-filled planets and moons that lack oceans—(how) do we measure their mountains? And even on Earth, how are the high and low tides of sea level reconciled in order to arrive at heights so specific that they often indicate individual feet, and even inches in some cases?
 
 ----
 
@@ -31,6 +31,8 @@ Text:
 <div class="pullquotesquare">
 </div>
 (text: Unfortunately, sea level is not level. The distance from the center of the Earth to the coast&shy;line is different around the world, not only because of winds and weather, but also as a result of the Earth's midsection bulge, which causes water {and everything else} to spread out at the equator. In addition, Earth is lumpy, with massive topographical features {such as mountains} altering the gravity in surrounding areas. class: l-textface pullquote)
+
+In the long run, though, snow might actually be more of a bane than a boone for a mountain’s height. Geologists had wondered for a while whether it was just a coincidence that taller peaks tended to cluster closer to the equator. That was until research into erosion rates done by David Egholm of Aarhus University in Denmark revealed that the slow, [tectonic-collision]-fueled growth of most mountains is no match for the mountain-munching forces of glaciers and ice. The snowline of crests at lower latitudes is likely to lie at a much higher elevation compared to the those of their more polar peaks, many of which are coated in a thick blanket of snow from tip to toe year round--and by blanket I mean gritty sandpaper that scours a mountain’s surface away, whole boulders at a time. This means that unless you’re lucky enough to be a Himalayan peak or a pinnacle in one of a handful of rare ranges whose vertical growth outpaces the damage done by glacial erosion, your height is likely to top off at about [1,500 meters] above your snowline, which in turn would seem to favor the equatorial summits, the snowlines of which are [staved off to higher elevations by their more tropical climates].
 
 I love (link: library#bbc-earth text: this planet). That's why I have such a cool (link: library#pentel-rolling-writers text: pen). The magnitude-7.8 earthquake that rocked Nepal in April 2015 may have changed the Himalayas' heights buy a couple of inches at most. But just how do scientists measure that miniscule level of change?
 

--- a/content/error/error.txt
+++ b/content/error/error.txt
@@ -1,4 +1,4 @@
-Title: Page not found
+Name: Page not found
 
 ----
 

--- a/site/blueprints/archive.yml
+++ b/site/blueprints/archive.yml
@@ -2,7 +2,7 @@ title: Archive
 
 //page settings
 deletable: false
-options: 
+options:
 	preview: true
 	status: false
 	template: false
@@ -17,7 +17,7 @@ files: false
 
 //fields with their field types and options
 fields:
-  title:
+  name:
     label: Page name
     type: text
     placeholder: Title for the 'archive' page
@@ -25,12 +25,12 @@ fields:
     label: Page description
     type: textarea
     placeholder: Optional explanation or instructions to readers about this page
-  years: 
+  years:
     label: Years
     type: structure
     style: table
     modalsize: small
-    fields: 
-      year: 
+    fields:
+      year:
         label: Year for Archive menu
         type: text

--- a/site/blueprints/error.yml
+++ b/site/blueprints/error.yml
@@ -3,7 +3,7 @@ title: Error
 pages: false
 files: false
 fields:
-  title:
+  name:
     label: Title
     type:  text
   text:

--- a/site/blueprints/hello.yml
+++ b/site/blueprints/hello.yml
@@ -30,7 +30,7 @@ files:
 
 //fields with their field types and options
 fields:
-  title:
+  name:
     label: Page name
     type: text
     placeholder: Title for the 'about' page

--- a/site/blueprints/library.yml
+++ b/site/blueprints/library.yml
@@ -2,7 +2,7 @@ title: Library
 
 //page settings
 deletable: false
-options: 
+options:
   preview: true
   status: false
   template: false
@@ -10,19 +10,19 @@ options:
   delete: false
 
 //subpage settings
-pages: 
+pages:
   template: libraryentry
   sort: flip
   limit: 100
-  num: 
+  num:
     mode: date
     format: d F Y
   hide: false
 
-//file settings 
-files: 
+//file settings
+files:
   sortable: true
-  type: 
+  type:
     - image
   fields:
     heading:
@@ -43,7 +43,7 @@ files:
 
 //fields with their field types and options
 fields:
-  title:
+  name:
     label: Page name
     type: text
     placeholder: Title for the 'library' page

--- a/site/blueprints/questionqueue.yml
+++ b/site/blueprints/questionqueue.yml
@@ -2,7 +2,7 @@ title: Question Queue
 
 //page settings
 deletable: true
-options: 
+options:
 	preview: true
 	status: false
 	template: false
@@ -10,7 +10,7 @@ options:
 	delete: false
 
 //subpage settings
-pages: 
+pages:
   template: qqbinoculars
 
 //file settings
@@ -18,7 +18,7 @@ files: false
 
 //fields with their field types and options
 fields:
-  title:
+  name:
     label: Page name
     type: text
     placeholder: Title for the 'question queue' page

--- a/site/snippets/head-title-all-but-home.php
+++ b/site/snippets/head-title-all-but-home.php
@@ -1,5 +1,4 @@
   <!-- This is what shows when you bookmark this page, and what's in the browser tab -->
   <title>
-    <?php echo $page->title()->html() ?> | Curiosity-Colored Glasses
+    <?php echo $page->name()->html() ?> | Curiosity-Colored Glasses
   </title>
-

--- a/site/snippets/header.php
+++ b/site/snippets/header.php
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
 
-  <title><?= $site->title()->html() ?> | <?= $page->title()->html() ?></title>
+  <title><?= $site->title()->html() ?> | <?= $page->name()->html() ?></title>
   <meta name="description" content="<?= $site->description()->html() ?>">
 
   <?= css('assets/css/index.css') ?>

--- a/site/snippets/menu.php
+++ b/site/snippets/menu.php
@@ -1,4 +1,4 @@
-<nav role="navigation"> 
+<nav role="navigation">
 
     <details id="navdetails" open>
 
@@ -7,7 +7,7 @@
 
             <!-- Home glasses icon -->
         <a href="<?php echo url('blog') ?>" title="Curiosity-Colored Glasses">
-            <img src="<?php echo url('assets/images/home.svg') ?>" alt="Curiosity-Colored Glasses" id="homeicon" class="yellowhover">   
+            <img src="<?php echo url('assets/images/home.svg') ?>" alt="Curiosity-Colored Glasses" id="homeicon" class="yellowhover">
         </a>
 
 		<ul id="navlist">
@@ -19,10 +19,10 @@
             <a <?php e($p->isOpen(), ' class="active"') ?> href="<?php echo $p->url() ?>" class="menuwordlink">
 
                 <li id="menuword" class="navnothome m-display yellowhover">
-                
+
                     <span <?php e($p->isOpen(), ' class="active2"') ?> href="<?php echo $p->url() ?>" >
 
-                    <?php echo $p->title()->html() ?></span></li>
+                    <?php echo $p->name()->html() ?></span></li>
 
             </a>
 

--- a/site/templates/archive.php
+++ b/site/templates/archive.php
@@ -3,7 +3,7 @@
 
 <?php snippet('head-title-all-but-home') ?>
 
- 
+
 <?php snippet('share-settings-common') ?>
 
 
@@ -31,7 +31,7 @@
                 <!-- title of the page + any intro text -->
                 <!-- NOT SURE IF THIS WILL STAY AS <h2> -->
                 <h2 class="extracontentpagetitle">
-                    <?php echo $page->title()->kirbytext() ?>
+                    <?php echo $page->name()->kirbytext() ?>
                 </h2>
 
                 <!-- text for the page -->
@@ -43,7 +43,7 @@
             </div>
 
 
-<!-- __________________________________________________________________________________ -->      
+<!-- __________________________________________________________________________________ -->
 
 <!-- ARCHIVE YEAR MENU -->
 
@@ -70,23 +70,23 @@
 
         </main>
 
-<!-- __________________________________________________________________________________ -->      
+<!-- __________________________________________________________________________________ -->
 
 
 <!-- THIS SECTION NEEDS TO BE HERE OR ELSE THE YEAR MENU WON'T SHOW UP -->
 
         <?php foreach($site->page('blog')
                            ->children()
-                           ->visible() 
+                           ->visible()
                            ->flip() as $result): ?>
 
-            <?php $date = getdate($result->date()); 
+            <?php $date = getdate($result->date());
             $tmpDate = $date; ?>
 
         <?php endforeach ?>
 
 
-<!-- __________________________________________________________________________________ -->      
+<!-- __________________________________________________________________________________ -->
 
 
 <!-- BLOG ARTICLES GROUPED BY YEAR -->
@@ -96,9 +96,9 @@
             <?php function pageYear($p) {
                 return $p->date('Y');    }    // year, e.g. "2016"
                 $posts = page('blog')->children(); ?>
-    
+
             <?php foreach ($posts->visible()->flip()->group('pageYear') as $year => $yearList): ?>
-    
+
                 <!-- year heading -->
                 <div id="archiveheadingarea">
                     <h3 class="sectionsummary archivesectionsummary blackbg" id="<?php echo $year?>" data-clickable-header="">
@@ -106,7 +106,7 @@
                         <?php echo $year ?>
                     </h3>
                 </div>
-                
+
 
                 <!-- area where results are per year -->
                 <div class="resultarea archiveresultarea">
@@ -122,5 +122,3 @@
 
 
     <?php snippet('footer-sitewide') ?>
-
-

--- a/site/templates/default.php
+++ b/site/templates/default.php
@@ -24,14 +24,14 @@
         <div class="desktopcontent">
 
             <!-- NOT SURE THAT THIS WILL STAY AS <h2> -->
-            <h2 id="pagetitle" class="extracontentpagetitle"><?php echo $page->title()->html() ?></h2>
+            <h2 id="pagetitle" class="extracontentpagetitle"><?php echo $page->name()->html() ?></h2>
 
 
             <!-- text for the page -->
             <span class="l-textface">
                 <?php echo $page->text()->kirbytext() ?>
             </span>
-    
+
 
             <!-- Image of broken glasses -->
 

--- a/site/templates/hello.php
+++ b/site/templates/hello.php
@@ -26,7 +26,7 @@
 				<!-- title of the page -->
 				<!-- NOT SURE IF THIS WILL STAY AS <h2> -->
 				<h2 class="extracontentpagetitle">
-					<?php echo $page->title()->kirbytext() ?>
+					<?php echo $page->name()->kirbytext() ?>
 				</h2>
 
 			</div>

--- a/site/templates/library.php
+++ b/site/templates/library.php
@@ -3,7 +3,7 @@
 
 <?php snippet('head-title-all-but-home') ?>
 
- 
+
 <?php snippet('share-settings-common') ?>
 
 
@@ -35,7 +35,7 @@
             <!-- title of the page -->
             <!-- NOT SURE IF THIS WILL END UP STAYING AS <h2> -->
             <h2 id="librarypagename" class="extracontentpagetitle">
-                <?php echo $page->title()->kirbytext() ?>
+                <?php echo $page->name()->kirbytext() ?>
             </h2>
 
 
@@ -46,7 +46,7 @@
             </span>
 
         </div>
-    
+
     </main>
 
 
@@ -55,8 +55,8 @@
         <!-- images + info stored in library folder directly (not library/libraryimages) -->
         <!-- info here is from metadata, info on blog article pages is from blogarticle.txt fields + custom CSS -->
         <?php foreach ($page->images()->sortBy('sort', 'asc') as $libraryresult): ?>
-        
-        <?php $librarysubpage = $libraryresult->name(); ?>  
+
+        <?php $librarysubpage = $libraryresult->name(); ?>
 
                 <!--
                 <img src="<?php echo $libraryresult->url() ?>" alt="<?php echo $libraryresult->alt() ?>" class="libraryicon" id="<?php echo $librarysubpage ?>">
@@ -94,8 +94,6 @@
 
 <script src="assets/js/library.js">
 </script>
-    
+
 
 <?php snippet('footer-sitewide') ?>
-
-

--- a/site/templates/questionqueue.php
+++ b/site/templates/questionqueue.php
@@ -36,7 +36,7 @@
     <!-- positions glasses -->
     <script src="assets/js/qq-position.js">
     </script>
-	
+
     <!-- parallax scroll -->
     <script src="assets/js/qq-parallax.js">
     </script>
@@ -44,13 +44,13 @@
     <!-- reveals question + content upon click -->
     <script src="assets/js/qq.js">
     </script>
-	
+
 
 <!-- *************************************** ^^^^^ LEAVE ALONE ^^^^^ *************************************** -->
 
 			<!-- title of the page -->
 			<h2 id="qqpagetitle">
-				<?php echo $page->title()->kirbytext() ?>
+				<?php echo $page->name()->kirbytext() ?>
 			</h2>
 
 			<span id="qqpagetext" class="l-textface">
@@ -60,14 +60,14 @@
         	<div id="qqparent">
 
 	        	<?php foreach ($page->children()->visible()->sortBy('sort', 'asc') as $qqfile): ?>
-	    	    
+
 		        <?php $qqsubpage = $qqfile->name(); ?>
 
 		        <!-- Setting up the margin-width randomizer for binoculars' relative positions -->
                 <?php $margins = array('0rem', '0.5rem', '1rem', '1.5rem', '2rem', '2.5rem'); ?>
                 <?php $rand_margin = $margins[array_rand($margins)]; ?>
     	    	<span class="qqpiece" style="margin-left: <?= $rand_margin ?>; margin-top: <?= $rand_margin ?>">
-				
+
 					<div data-clickable="yes" data-id="<?php echo $qqfile->title() ?>" class="qqglassescontainer <?php if ($qqfile->binocsize() == 'large'): ?>largeqqglasses<?php endif ?><?php if ($qqfile->binocsize() == 'medium'): ?>mediumqqglasses<?php endif ?><?php if ($qqfile->binocsize() == 'small'): ?>smallqqglasses<?php endif ?>" title="<?php echo $qqfile->question() ?>" alt="<?php echo $qqfile->question() ?>">
     			    	<?php if($leftbinoclens = $qqfile->binocimageleft()->toFile()): ?>
                             <div data-innards-clickable="yes" class="lens l-lens" style="background-image: url(<?php echo $leftbinoclens->url() ?>)"></div>
@@ -79,14 +79,14 @@
                         <?php endif; ?>
     		    	</div>
 
-					<div class="qqcontents <?php if ($qqfile->binocsize() == 'large'): ?>qqcontents-large<?php endif ?><?php if ($qqfile->binocsize() == 'medium'): ?>qqcontents-medium<?php endif ?><?php if ($qqfile->binocsize() == 'small'): ?>qqcontents-small<?php endif ?>" style="display: none;" data-edgemargin="">						
+					<div class="qqcontents <?php if ($qqfile->binocsize() == 'large'): ?>qqcontents-large<?php endif ?><?php if ($qqfile->binocsize() == 'medium'): ?>qqcontents-medium<?php endif ?><?php if ($qqfile->binocsize() == 'small'): ?>qqcontents-small<?php endif ?>" style="display: none;" data-edgemargin="">
 						<div class="sharkfin"></div>
 						<div class="bordercover"></div>
 						<img src= "<?php echo url('assets/images/x.svg') ?>" alt="close" id="qq-x" class="yellowhover close-x">
 						<div class="qqquestion s-display"><?php echo $qqfile->question()->kirbytext() ?></div>
 						<div class="qqdescription s-textface"><?php echo $qqfile->explanation()->kirbytext() ?></div>
 					</div>
-					
+
 				</span>
 
     		    <?php endforeach ?>
@@ -104,33 +104,3 @@
 </body>
 
 </html>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Last fix related to the search fix (that excluded content sub-folders from results); now Hello, QQ, Library, and Archive pages blueprints call for `name` instead of `title`, and their HTML head <title> tags point to these, so they properly appear in the browser tabs and bookmark default names.