### PR TITLE
QQ page title now matches height of Library, Archive, Hello page titles

### DIFF
--- a/assets/css/qq.css
+++ b/assets/css/qq.css
@@ -10,7 +10,7 @@
 	left: calc(50vw - 322px);	}
 
 #qqpagetitle p {
-	padding-top: calc(10.714vw - 0.25rem);
+	/* padding-top: calc(10.714vw - 0.25rem); */
 	margin: 0 auto 1.536rem auto;    }
 
 #qqpagetext p {

--- a/site/templates/questionqueue.php
+++ b/site/templates/questionqueue.php
@@ -49,7 +49,7 @@
 <!-- *************************************** ^^^^^ LEAVE ALONE ^^^^^ *************************************** -->
 
 			<!-- title of the page -->
-			<h2 id="qqpagetitle">
+			<h2 id="qqpagetitle" class="extracontentpagetitle">
 				<?php echo $page->name()->kirbytext() ?>
 			</h2>
 


### PR DESCRIPTION
I don't know what caused it to slip down lower than it had been before the previous commit! But now the same CSS applies to them all.