### PR TITLE
Cleaning up the comment id to match its count instead of messy uid nu…

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -231,7 +231,8 @@ that will be recognized in JS menu.js script, that can have an event listener ap
             {%- assign url             = comment.url %}
             {%- assign date            = comment.date %}
             {%- assign message         = comment.message %}
-            {%- assign uid             = comment._id %}
+            <!-- {%- assign uid             = comment._id %} -->
+            {%- assign uid             = forloop.index %}
             {% include comment.html is_reply=false uid=uid replying_to=0 email=email name=name url=url date=date message=message uid=uid %}
           {% endfor %}
 


### PR DESCRIPTION
…mber

Now anchor links to individual comments will have the hash with the comment count