### PR TITLE
Pinterest script does require double slashes at its start

### DIFF
--- a/_layouts/hello.html
+++ b/_layouts/hello.html
@@ -34,7 +34,7 @@ that will be recognized in JS menu.js script, that can have an event listener ap
               </footer>
 
               <!--This is the pinterest script, instructed to place right before closing </body> tag-->
-              <script async defer src="{{ site.baseurl }}/assets.pinterest.com/js/pinit.js">
+              <script async defer src="//assets.pinterest.com/js/pinit.js">
               </script>
 
               <!--This encompasses everything within <body> except for <nav>. This is so that there is an element that can be clicked on that will be anything except <nav>, that will be recognized in JS menu.js script, that can have an event listener applied when it is clicked on, that will close the <nav> -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -249,7 +249,7 @@ that will be recognized in JS menu.js script, that can have an event listener ap
               </footer>
 
               <!--This is the pinterest script, instructed to place right before closing </body> tag-->
-              <script async defer src="{{ site.baseurl }}/assets.pinterest.com/js/pinit.js">
+              <script async defer src="//assets.pinterest.com/js/pinit.js">
               </script>
 
               <!--This encompasses everything within <body> except for <nav>. This is so that there is an element that can be clicked on that will be anything except <nav>, that will be recognized in JS menu.js script, that can have an event listener applied when it is clicked on, that will close the <nav> -->


### PR DESCRIPTION
              <script async defer src="//assets.pinterest.com/js/pinit.js">
              </script>