### PR TITLE
It seems that commenting out part of the FB script actually did nothing

### DIFF
--- a/_includes/facebook-sdk.html
+++ b/_includes/facebook-sdk.html
@@ -1,9 +1,4 @@
-<!-- This snippet lives inside the header-close.php snippet. -->
-<!-- The Facebook SDK is supposed to be inserted "directly after ... -->
-<!-- ... the opening <body> tag on each page you want to load it" -->
-<!-- Being within header-close.php, it will be available to every page I want a share button on. -->
-
-
+<!-- From Facebook Developers -->
 <script>
   window.fbAsyncInit = function() {
     FB.init({
@@ -12,15 +7,11 @@
       version    : 'v2.8'
     });
   };
-  
-<!--
-  (function(d, s, id){
-     var js, fjs = d.getElementsByTagName(s)[0];
-     if (d.getElementById(id)) {return;}
-     js = d.createElement(s); js.id = id;
-     js.src = "//connect.facebook.net/en_US/sdk.js";
-     fjs.parentNode.insertBefore(js, fjs);
-   }(document, 'script', 'facebook-jssdk'));
-   -->
-
+    (function(d, s, id){
+       var js, fjs = d.getElementsByTagName(s)[0];
+       if (d.getElementById(id)) {return;}
+       js = d.createElement(s); js.id = id;
+       js.src = "//connect.facebook.net/en_US/sdk.js";
+       fjs.parentNode.insertBefore(js, fjs);
+     }(document, 'script', 'facebook-jssdk'));
 </script>


### PR DESCRIPTION
And deleting it rendered FB share button unusable again (nothing happens when click on it). So I removed the comment-outs and now it works as expected (for the time being at least...)