### PR TITLE
Mobile devices only using Chrome display warning icon in URL bar for …

### DIFF
--- a/collections/_posts/2021-06-15-state-of-research.md
+++ b/collections/_posts/2021-06-15-state-of-research.md
@@ -3,7 +3,7 @@ title: Rare as One&#58;	 State of Research
 author: Lia Prins
 tags:
 excerpt:
-comments: false
+comments: true
 rightextension: .png
 d3:
   - graphs/state-of-research/state-of-research.js


### PR DESCRIPTION
…security...

... but only on Martian mtns page. Checking if related to comments by adding `comments: true` to RA1 hidden page to see if afterwards it also gets the warning icon.