### PR TITLE
Reinstating count of comments in case it somehow affected the security

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -260,7 +260,14 @@ layout: default
 
       <!-- If there are existing comments -->
       {% if site.data.comments[page.slug] %}
-      {% assign comments = site.data.comments[page.slug] | where_exp: "item", "item.replying_to_uid == ''" %}
+        {% assign comments = site.data.comments[page.slug] | where_exp: "item", "item.replying_to_uid == ''" %}
+          {% for commentcounter in comments %}
+            {% if forloop.first %}
+              <summary class="sectionsummary postpagesectionsummary commentssummary blackbg">
+                <h3>Comments: {{ forloop.length }}</h3>
+              </summary>
+            {% endif %}
+          {% endfor %}
         <!-- Pulling in existing comments -->
         {% assign comments_by_date = comments | sort: 'date' %}
         {% for comment in comments_by_date %}
@@ -284,6 +291,11 @@ layout: default
             </a>
           </article>
         {% endfor %}
+        <!-- If there are not existing comments -->
+        {% else %}
+          <summary class="sectionsummary postpagesectionsummary commentssummary blackbg">
+            <h3>Comments</h3>
+          </summary>
       {% endif %}
 
         <!-- The comment-entry area -->

--- a/collections/_posts/2021-06-15-state-of-research.md
+++ b/collections/_posts/2021-06-15-state-of-research.md
@@ -3,7 +3,7 @@ title: Rare as One&#58;	 State of Research
 author: Lia Prins
 tags:
 excerpt:
-comments: true
+comments: false
 rightextension: .png
 d3:
   - graphs/state-of-research/state-of-research.js


### PR DESCRIPTION
Since my previous test proved the security issue is caused by the presence of comments section, but everything had been fine even when there has constantly been the comments section