### PR TITLE
_TEMPLATE.md files for Library + QQ content

### DIFF
--- a/collections/_librarycontent/_TEMPLATE.md
+++ b/collections/_librarycontent/_TEMPLATE.md
@@ -1,0 +1,9 @@
+---
+title: LIBRARYENTRYNAME
+alttext: ALTTEXT
+---
+
+*ITALICTEXT* 
+__BOLDTEXT__ 
+[VISIBLELINKTEXT](HYPERLINK){:target="_blank"}.
+

--- a/collections/_questionqueuecontent/_TEMPLATE.md
+++ b/collections/_questionqueuecontent/_TEMPLATE.md
@@ -1,0 +1,7 @@
+---
+question: QUESTION
+---
+
+*ITALICTEXT* 
+__BOLDTEXT__ 
+[VISIBLELINKTEXT](HYPERLINK){:target="_blank"}.


### PR DESCRIPTION
_TEMPLATE.md files within collections / _librarycontent and collections / _questionqueuecontent folders

I only preceded the file names with an underscore so they'd go to the top of the list and be quick to find; they do NOT need the underscore for any Jekyll purpose (like the _questionqueuecontent folder needs it). So far it doesn't seem to be messing anything up even though it does have the preceding underscore and doesn't need it...